### PR TITLE
Fixed a typo in default

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,5 +1,5 @@
 Rails.application.configure do
-  config.action_mailer.defaultl_url_options = { host: 'localhost', port: 3000 }
+  config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
   # Settings specified here will take precedence over those in config/application.rb.
 
   # In the development environment your application's code is reloaded on


### PR DESCRIPTION
```
  config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
``` 
should be this