### PR TITLE
Fix for travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ script:
   - bundle exec rspec
   
 before_install:
+  - bundle install --no-deployment
   - gem update bundler
 
 services:


### PR DESCRIPTION
Added 
```
before_install:
  - bundle install --no-deployment
```
since travis ci throws this error back ```You are trying to install in deployment mode after changing```
Read the docs here https://docs.travis-ci.com/user/languages/ruby/