### PR TITLE
Updated gemfile for heroku fixes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,15 @@ gem 'jbuilder', '~> 2.5'
 # Official manual http://docs.rubocop.org/en/latest/
 gem 'rubocop', '~> 0.58.2', require: false
 
+# Figaro adds protected keys
+gem 'figaro'
+
+gem 'omniauth'
+#authentication for facebook users
+gem 'omniauth-facebook'
+#authentication for google users
+gem 'omniauth-google-oauth2'
+
 
 group :development, :test do
   gem 'byebug', platform: :mri
@@ -34,14 +43,6 @@ group :development do
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
 
-  # Figaro adds protected keys
-  gem 'figaro'
-
-  gem 'omniauth'
-  #authentication for facebook users
-  gem 'omniauth-facebook'
-  #authentication for google users
-  gem 'omniauth-google-oauth2'
 end
 
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]


### PR DESCRIPTION
Moved figaro, omniauth, omniauth-facebook, omniauth-google-oauth2 gems out of the development group. So that these gems are provided for both production and development.